### PR TITLE
alias setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var originalSetTimeout = setTimeout;
+
 module.exports = function(fn, options) {
   if (typeof options === 'function') {
     var opts = fn;
@@ -85,6 +87,6 @@ module.exports.ensuring = function (fn, options) {
 
 function wait(n) {
   return new Promise(function (fulfil) {
-    setTimeout(fulfil, n);
+    originalSetTimeout(fulfil, n);
   });
 }


### PR DESCRIPTION
aliased setTimeout for cases where setTimeout implementation is changed after trytryagain is loaded.
this happens when using https://github.com/featurist/unset-timeout
